### PR TITLE
Build cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN dnf update -y && \
-    dnf install -y flatpak flatpak-builder xorg-x11-server-Xvfb && \
+    dnf install -y flatpak flatpak-builder xorg-x11-server-Xvfb ccache && \
     dnf clean all
 
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ const build = async (manifest, manifestPath, bundle, runtimeRepo, buildDir, repo
         "--disable-rofiles-fuse",
         "--install-deps-from=flathub",
         "--force-clean",
+        "--ccache",
         buildDir,
         manifestPath,
     ])

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ const build = async (manifest, manifestPath, bundle, runtimeRepo, buildDir, repo
         `--repo=${repoName}`,
         "--disable-rofiles-fuse",
         "--install-deps-from=flathub",
+        "--force-clean",
         buildDir,
         manifestPath,
     ])


### PR DESCRIPTION
This is a quick and dirty approach to fix https://github.com/bilelmoussaoui/flatpak-github-actions/issues/15.

It at least allows using the `cache` action to cache the build directory, and restore it for the next build. Here's an example: https://github.com/GeorgesStavracas/obs-studio/commit/64b9e43ca07c169cc929f6feef7529a4398263d6