### PR TITLE
Ccache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN dnf update -y && \
-    dnf install -y flatpak flatpak-builder xorg-x11-server-Xvfb && \
+    dnf install -y flatpak flatpak-builder xorg-x11-server-Xvfb ccache && \
     dnf clean all
 
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
Install it in the Docker image so that it can be used in the future for caching build objects.