### PR TITLE
flatpak-builder: List mirror-screenshots-url in action.yml

### DIFF
--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -50,6 +50,10 @@ inputs:
       The CPU architecture to build for.
     default: "x86_64"
     required: false
+  mirror-screenshots-url:
+    description: >
+      The URL to mirror screenshots.
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"


### PR DESCRIPTION
This was an oversight of the previous commits.