### PR TITLE
add keep-build-dirs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ jobs:
 | `build-dir` | The directory to build the application in. | Optional | `flatpak_app` |
 | `repo-dir` | The directory of the flatpak repository. | Optional | `repo` |
 | `state-dir` | The directory to store the build state/cache in. | Optional | `.flatpak-builder` |
+| `keep-build-dirs` | Keep build directories after the build finishes (passes `--keep-build-dirs` to flatpak-builder). Useful for debugging intermediate files. | Optional | `false` |
 | `verbose` | Enable verbosity | Optional | `false` |
 | `upload-artifact` | Whether to upload the resulting bundle or not as an artifact | Optional | `true` |
 

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -56,6 +56,13 @@ inputs:
       Defines the cache-key to use.
       Defaults to flatpak-builder-${arch}-${sha256(manifestPath)}
     required: false
+  keep-build-dirs:
+    description: >
+      Keep build directories after the build finishes, passing `--keep-build-dirs` flag
+      to flatpak-builder.
+      Possible values: true, enabled, yes, y. Defaults to false.
+    required: false
+    default: "false"
   branch:
     description: The flatpak branch.
     default: "master"

--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -46,6 +46,8 @@ class Configuration {
     this.mirrorScreenshotsUrl = core.getInput('mirror-screenshots-url')
     // The key to sign the package
     this.gpgSign = core.getInput('gpg-sign')
+    // Keep build directories after the build (pass --keep-build-dirs)
+    this.keepBuildDirs = core.getBooleanInput('keep-build-dirs')
     // Modified manifest path
     this.modifiedManifestPath = path.join(
       path.dirname(this.manifestPath),
@@ -229,6 +231,9 @@ const build = async (manifest, manifestPath, cacheHitKey, config) => {
     `--default-branch=${branch}`,
     `--arch=${config.arch}`
   ]
+  if (config.keepBuildDirs) {
+    args.push('--keep-build-dirs')
+  }
   if (config.cacheBuildDir) {
     args.push('--ccache')
   }


### PR DESCRIPTION
This will enable users run `meson dist` after a successfull build.
Or in general, to extract some files from the build dir