### PR TITLE
flatpak-builder: Add ability to override artifact name

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -131,6 +131,48 @@ jobs:
           cache-key: flatpak-builder-${{ github.sha }}-debug-bundle
           verbose: true
 
+  flatpak-builder-artifact-name:
+    name: Flatpak Builder Artifact Name
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - bundle:
+          artifact-name:
+          expected-artifact: app-x86_64.flatpak
+
+        - bundle: org.example.MyApp.Devel-artifact-name.flatpak
+          artifact-name:
+          expected-artifact: org.example.MyApp.Devel-artifact-name-x86_64.flatpak
+
+        - bundle: org.example.MyApp.Devel-artifact-empty-name.flatpak
+          artifact-name: ""
+          expected-artifact: org.example.MyApp.Devel-artifact-empty-name-x86_64.flatpak
+
+        - bundle: org.example.MyApp.Devel-artifact-name.flatpak
+          artifact-name: org.example.MyApp.Devel-artifact-name.flatpak
+          expected-artifact: org.example.MyApp.Devel-artifact-name.flatpak
+
+        - bundle:
+          artifact-name: artifact-name-test
+          expected-artifact: artifact-name-test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./flatpak-builder
+        with:
+          bundle: ${{ matrix.bundle }}
+          artifact-name: ${{ matrix.artifact-name }}
+          manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
+          verbose: true
+          arch: x86_64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.expected-artifact }}
+
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -117,7 +117,6 @@ jobs:
   flatpak-builder-debug-bundle:
     name: Flatpak Builder Debug Bundle
     runs-on: ubuntu-latest
-    needs: flatpak-builder
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
       options: --privileged

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
 | `keep-build-dirs` | Keep build directories after the build finishes (passes `--keep-build-dirs` to flatpak-builder). Useful for debugging intermediate files. | Optional | `false` |
 | `verbose` | Enable verbosity | Optional | `false` |
 | `upload-artifact` | Whether to upload the resulting bundle or not as an artifact | Optional | `true` |
+| `artifact-name` | Name of the uploaded artifact | Optional | `app-${arch}.flatpak` |
 
 **Note**: `repo-dir` and `state-dir` must be under the same partition.
 

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -106,6 +106,10 @@ inputs:
       "Whether to upload the resulting bundle or not as an artifact"
     required: false
     default: "true"
+  artifact-name:
+    description: >
+      "Name of the uploaded artifact. Defaults to the bundle name tagged with the architecture"
+    required: false
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/flatpak-builder/dist/index.js
+++ b/flatpak-builder/dist/index.js
@@ -72,6 +72,11 @@ class Configuration {
     this.verbose = core.getBooleanInput('verbose')
     // Upload the artifact
     this.uploadArtifact = core.getBooleanInput('upload-artifact')
+    // Artifact name
+    this.artifactName = core.getInput('artifact-name') ||
+      // Append the arch to the bundle name to prevent conflicts in multi-arch jobs
+      // If a name is provided, it's on the user to prevent this
+      this.bundle.replace('.flatpak', '') + `-${this.arch}.flatpak`
   }
 
   async cacheKey () {
@@ -432,10 +437,8 @@ const run = async (config) => {
 
       const artifactClient = new DefaultArtifactClient()
       core.info('Uploading artifact...')
-      // Append the arch to the bundle name to prevent conflicts in multi-arch jobs
-      const bundleName = config.bundle.replace('.flatpak', '') + `-${config.arch}.flatpak`
       const artifactFiles = config.buildDebugBundle ? [config.bundle, config.debugBundle] : [config.bundle]
-      return artifactClient.uploadArtifact(bundleName, artifactFiles, '.', {
+      return artifactClient.uploadArtifact(config.artifactName, artifactFiles, '.', {
         continueOnError: false
       })
     })

--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -66,6 +66,11 @@ class Configuration {
     this.verbose = core.getBooleanInput('verbose')
     // Upload the artifact
     this.uploadArtifact = core.getBooleanInput('upload-artifact')
+    // Artifact name
+    this.artifactName = core.getInput('artifact-name') ||
+      // Append the arch to the bundle name to prevent conflicts in multi-arch jobs
+      // If a name is provided, it's on the user to prevent this
+      this.bundle.replace('.flatpak', '') + `-${this.arch}.flatpak`
   }
 
   async cacheKey () {
@@ -426,10 +431,8 @@ const run = async (config) => {
 
       const artifactClient = new DefaultArtifactClient()
       core.info('Uploading artifact...')
-      // Append the arch to the bundle name to prevent conflicts in multi-arch jobs
-      const bundleName = config.bundle.replace('.flatpak', '') + `-${config.arch}.flatpak`
       const artifactFiles = config.buildDebugBundle ? [config.bundle, config.debugBundle] : [config.bundle]
-      return artifactClient.uploadArtifact(bundleName, artifactFiles, '.', {
+      return artifactClient.uploadArtifact(config.artifactName, artifactFiles, '.', {
         continueOnError: false
       })
     })


### PR DESCRIPTION
Fixes #54 with some additional flexibility.
Setting `artifact-name` the same string used for `bundle` will have the effect of removing the architecture from the artifact name, but it can also be set to any other string if wanted.

I wasn't quite sure the best way to indicate the default in the readme or description field.